### PR TITLE
removes language_level from CythonCompilerDirectives

### DIFF
--- a/src/hwh_backend/hwh_config.py
+++ b/src/hwh_backend/hwh_config.py
@@ -32,9 +32,6 @@ class CythonCompilerWarningDirectives:
 class CythonCompilerDirectives:
     # see https://cython.readthedocs.io/en/0.29.x/src/userguide/source_files_and_compilation.html#compiler-directives
     # Defaults are documentation's defauls
-    language_level: str = "3"
-    VALID_LANGUAGE_LEVELS = {"2", "3", "3str"}
-
     binding: bool = False
     boundscheck: bool = True
     wraparound: bool = True
@@ -88,17 +85,6 @@ class CythonCompilerDirectives:
                         f"got {type(field_value).__name__}"
                     )
 
-            # Value validation for language level
-            # FIXME: Should be StrEnum
-            if (
-                field_name == "language_level"
-                and field_value not in self.VALID_LANGUAGE_LEVELS
-            ):
-                raise ValueError(
-                    f"language_level must be one of {self.VALID_LANGUAGE_LEVELS}, "
-                    f"got '{field_value}'"
-                )
-
 
 @dataclass
 class CythonConfig:
@@ -126,10 +112,9 @@ class CythonConfig:
             try:
                 self.language = Language(self.language.lower())
             except ValueError as e:
+                valid_options = [lang.value for lang in Language]
                 raise ValueError(
-                    f"Invalid language: {self.language}. Valid options {
-                        [lang.value for lang in Language]
-                    }"
+                    f"Invalid language: {self.language}. Valid options {valid_options}"
                 ) from e
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,6 @@ language="c"
 annotate=false
 
 [tool.hwh.cython.compiler_directives]
-language_level = "3"
 binding = false
 boundscheck = false
 wraparound = false

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -10,13 +10,12 @@ from hwh_backend.hwh_config import (
 
 @pytest.fixture
 def minimal_config():
-    return {"language": "c", "compiler_directives": {"language_level": "3"}}
+    return {"language": "c", "compiler_directives": {}}
 
 
 def test_basic_config(minimal_config):
     config = CythonConfig(**minimal_config)
     assert config.language == Language.C
-    assert config.compiler_directives.language_level == "3"
 
 
 def test_site_packages_config():
@@ -30,8 +29,8 @@ def test_invalid_language():
 
 
 def test_compiler_directives_validation():
-    with pytest.raises(ValueError):
-        CythonCompilerDirectives(language_level="invalid")
+    with pytest.raises(TypeError):
+        CythonCompilerDirectives(boundscheck="invalid")
 
 
 def test_compiler_directives_types():
@@ -48,9 +47,7 @@ def test_complete_config():
         library_dirs=["/usr/lib"],
         runtime_library_dirs=["/usr/lib"],
         site_packages=SitePackages.SITE,
-        compiler_directives=CythonCompilerDirectives(
-            language_level="3", boundscheck=False
-        ),
+        compiler_directives=CythonCompilerDirectives(boundscheck=False),
     )
     assert config.language == Language.CPP
     assert len(config.sources) == 2

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -40,4 +40,3 @@ def test_hwh_config(tmp_path, sample_pyproject):
     parser = PyProject(project_dir)
     config = parser.get_hwh_config()
     assert config.cython.language == "c"
-    assert config.cython.compiler_directives.language_level == "3"

--- a/tests/utils/package_utils.py
+++ b/tests/utils/package_utils.py
@@ -33,7 +33,7 @@ requires-python = ">=3.11"
     content += """
 [tool.hwh.cython]
 language = "c"
-compiler_directives = { language_level = "3" }
+compiler_directives = { }
 """
 
     with open(pkg_dir / "pyproject.toml", "w") as f:


### PR DESCRIPTION
We support Python 3 only, so language_level causes just confusion