### PR TITLE
12 switch to dynamic versioning with setuptools scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel>=0.40.0"]
+requires = ["setuptools>=68.0", "wheel>=0.40.0", "setuptools-scm>=8.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -47,6 +47,10 @@ Repository = "https://github.com/mkgessen/hwh-backend.git"
 [tool.setuptools]
 packages = ["hwh_backend"]
 package-dir = { "" = "src" }
+
+[tool.setuptools_scm]
+version_scheme = "post-release"
+local_scheme = "dirty-tag"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hwh-backend"
-version = "0.2.1"
+dynamic = ["version"]
 description = "Setuptools based backend supporting Cython extensions"
 authors = [
     { name = "Mathias von Essen", email = "3090690+mkgessen@users.noreply.github.com" },


### PR DESCRIPTION
Switches from static version in pyproject.toml to `setuptools-scm`, see #12 
Tests pass and tag looks ok when publishing to testpypi.