### PR TITLE
10 libraries directive

### DIFF
--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -206,6 +206,8 @@ def _get_ext_modules(project: PyProject, config_settings: Optional[dict] = None)
             include_dirs=include_dirs,
             language=config.language,
             library_dirs=library_dirs,
+            libraries=config.libraries,
+            extra_link_args=config.extra_link_args,
             runtime_library_dirs=runtime_library_dirs,
         )
         logger.debug(f"Created Extension object: {ext.name}")

--- a/src/hwh_backend/hwh_config.py
+++ b/src/hwh_backend/hwh_config.py
@@ -113,6 +113,8 @@ class CythonConfig:
     exclude_dirs: list[str] = field(default_factory=list)
     include_dirs: list[str] = field(default_factory=list)
     library_dirs: list[str] = field(default_factory=list)
+    extra_link_args: list[str] = field(default_factory=list)
+    libraries: list[str] = field(default_factory=list)
     runtime_library_dirs: list[str] = field(default_factory=list)
     site_packages: SitePackages = field(default=SitePackages.PURELIB)
 
@@ -157,6 +159,8 @@ class CythonConfig:
             exclude_dirs=exclude_dirs,
             include_dirs=include_dirs,
             library_dirs=library_dirs,
+            libraries=modules.get("libraries", []),
+            extra_link_args=modules.get("extra_link_args", []),
             runtime_library_dirs=runtime_library_dirs,
             site_packages=cython_config.get("site_packages") or SitePackages.PURELIB,
             use_numpy_include=cython_config.get("use_numpy_include", False),

--- a/tests/integration/test_library_linking.py
+++ b/tests/integration/test_library_linking.py
@@ -1,0 +1,116 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from ..utils.package_utils import create_test_package
+from ..utils.venv_utils import create_virtual_env, run_in_venv, setup_test_env
+from ..utils.verification_utils import verify_installation
+
+
+def create_shared_lib(pkg_dir: Path) -> Path:
+    """Create .so +header"""
+    lib_dir = pkg_dir / "lib"
+    lib_dir.mkdir(exist_ok=True)
+
+    lib_source = lib_dir / "testlib.c"
+    lib_source.write_text("""
+    #include <stdio.h>
+    int multiply_by_two(int x) {
+        return x * 2;
+    }
+    """)
+
+    header = lib_dir / "testlib.h"
+    header.write_text("""
+    #ifndef TESTLIB_H
+    #define TESTLIB_H
+    int multiply_by_two(int x);
+    #endif
+    """)
+
+    subprocess.run(
+        [
+            "gcc",
+            "-shared",
+            "-fPIC",
+            str(lib_source),
+            "-o",
+            str(lib_dir / "libtestlib.so"),
+        ],
+        check=True,
+    )
+
+    return lib_dir
+
+
+@pytest.fixture
+def linked_package(tmp_path: Path, backend_dir: Path):
+    """Create a test package that links against the .so"""
+    # Define Cython extension that uses the library
+    cython_files = {
+        "math.pyx": '''
+# distutils: language = c
+cdef extern from "testlib.h":
+    int multiply_by_two(int x)
+
+def double_value(x: int) -> int:
+    """Double the input value using the external library."""
+    return multiply_by_two(x)
+''',
+    }
+
+    package = create_test_package(
+        tmp_path,
+        "linked-package",
+        cython_files,
+        backend_dir,
+        pkg_dir_name="linked_package",
+    )
+
+    lib_dir = create_shared_lib(package)
+
+    pyproject = package / "pyproject.toml"
+    config = pyproject.read_text()
+    config += f"""
+[tool.hwh.cython.modules]
+libraries = ["testlib"]
+library_dirs = ["{lib_dir}"]
+runtime_library_dirs = ["{lib_dir}"]
+include_dirs = ["{lib_dir}"]
+"""
+    pyproject.write_text(config)
+
+    test_script = package / "scripts" / "test_linking.py"
+    test_script.write_text("""
+from linked_package.math import double_value
+print(f"Result: {double_value(21)}")
+""")
+
+    return package
+
+
+def test_library_linking(tmp_path: Path, linked_package: Path):
+    """Test that extension successfully links against shared library."""
+    # Create and set up virtual environment
+    backend_dir = Path(__file__).parent.parent.parent.absolute()
+
+    venv_dir = create_virtual_env(tmp_path / "venv")
+    setup_test_env(venv_dir, backend_dir)
+
+    # Install the package
+    run_in_venv(
+        venv_dir,
+        [
+            "pip",
+            "install",
+            "--no-build-isolation",
+            "--config-setting",
+            "verbose=debug",
+            str(linked_package),
+        ],
+        show_output=True,
+    )
+
+    test_script = linked_package / "scripts" / "test_linking.py"
+    verify_installation(venv_dir, test_script, "Result: 42")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,4 +1,5 @@
 import pytest
+import tomli_w
 
 from hwh_backend.hwh_config import (
     CythonCompilerDirectives,
@@ -62,7 +63,31 @@ def test_cython_compiler_directives_constant_language_level():
     assert result["language_level"] == "3"  # Still present and unchanged
 
 
-def test_complete_config():
+def test_library_config():
+    """Test configuration with library settings."""
+    config = CythonConfig(
+        libraries=["foo", "bar"],
+        library_dirs=["/usr/local/lib", "/opt/lib"],
+        runtime_library_dirs=["/usr/local/lib"],
+        extra_link_args=["-Wl,--no-as-needed"],
+    )
+    assert config.libraries == ["foo", "bar"]
+    assert config.library_dirs == ["/usr/local/lib", "/opt/lib"]
+    assert config.runtime_library_dirs == ["/usr/local/lib"]
+    assert config.extra_link_args == ["-Wl,--no-as-needed"]
+
+
+def test_library_config_defaults():
+    """Test default values for library settings."""
+    config = CythonConfig()
+    assert config.libraries == []
+    assert config.library_dirs == []
+    assert config.runtime_library_dirs == []
+    assert config.extra_link_args == []
+
+
+def test_complete_config_with_libraries():
+    """Test complete configuration including library settings."""
     config = CythonConfig(
         language=Language.CPP,
         sources=["src1.pyx", "src2.pyx"],
@@ -70,9 +95,49 @@ def test_complete_config():
         include_dirs=["/usr/include"],
         library_dirs=["/usr/lib"],
         runtime_library_dirs=["/usr/lib"],
+        libraries=["foo"],
+        extra_link_args=["-Wl,--as-needed"],
         site_packages=SitePackages.SITE,
         compiler_directives=CythonCompilerDirectives(boundscheck=False),
     )
     assert config.language == Language.CPP
     assert len(config.sources) == 2
+    assert config.libraries == ["foo"]
+    assert config.extra_link_args == ["-Wl,--as-needed"]
     assert not config.compiler_directives.boundscheck
+
+
+def test_library_config_from_pyproject(tmp_path):
+    """Test parsing library configuration from pyproject.toml."""
+
+    from hwh_backend.parser import PyProject
+
+    test_config = {
+        "project": {"name": "test-project", "version": "0.1.0"},
+        "tool": {
+            "hwh": {
+                "cython": {
+                    "language": "c++",
+                    "modules": {
+                        "libraries": ["foo", "bar"],
+                        "library_dirs": ["/usr/local/lib"],
+                        "runtime_library_dirs": ["/usr/local/lib"],
+                        "extra_link_args": ["-Wl,--no-as-needed"],
+                    },
+                }
+            }
+        },
+    }
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    with open(pyproject_path, "wb") as f:
+        tomli_w.dump(test_config, f)
+
+    project = PyProject(tmp_path)
+    config = project.get_hwh_config().cython
+
+    assert config.language == Language.CPP
+    assert config.libraries == ["foo", "bar"]
+    assert config.library_dirs == ["/usr/local/lib"]
+    assert config.runtime_library_dirs == ["/usr/local/lib"]
+    assert config.extra_link_args == ["-Wl,--no-as-needed"]

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -40,7 +40,7 @@ def test_compiler_directives_types():
 
 
 def test_cython_compiler_directives_constant_language_level():
-    """Test that language_level is constant and properly included in as_dict()."""
+    # TODO: delete - no point of testing language level, since we only accept 3
     directives = CythonCompilerDirectives()
 
     # Test that language_level is constant


### PR DESCRIPTION
Adds the missing libraries directive to hwh.cython.

```toml

[build-system]
requires = [
    "hwh-backend",
    "Cython<3.0.0"
]
build-backend = "hwh_backend.build"

[project]
name = "linked-package"
version = "0.1.0"
requires-python = ">=3.11"

[tool.setuptools.packages.find]
where = ["."]  # or ["src"] if using src layout
include = ["linked_package*"]  # includes subpackages

[tool.hwh.cython]
language = "c"

[tool.hwh.cython.modules]
libraries = ["testlib"]
library_dirs = ["/path-to/linked-package/lib"]
runtime_library_dirs = ["/path-to/linked-package/lib"]
include_dirs = ["path-to/linked-package/include"]
```