### PR TITLE
Fix/setuptools package discovery

### DIFF
--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -350,23 +350,17 @@ def _build_extension(
 
     project = PyProject(Path())
     name = project.package_name
-    packages = project.packages
 
     dist_kwargs = {
         "name": name,
         "version": str(project.package_version),
         "ext_modules": _get_ext_modules(project, config_settings=config_settings),
-        "packages": packages,
-        "package_data": {pkg: ["*.pxd", "*.so"] for pkg in packages},
+        "packages": project.packages,
+        "package_data": {pkg: ["*.pxd", "*.so"] for pkg in project.packages},
         "include_package_data": True,
     }
 
-    # Add where/src-layout specific configuration
-    packages_find = project.setuptools_config.get("packages", {}).get("find", {})
-    if where_paths := packages_find.get("where", []):
-        if isinstance(where_paths, str):
-            where_paths = [where_paths]
-        dist_kwargs["package_dir"] = {"": where_paths[0]}
+    dist_kwargs["package_dir"] = project.package_dir or project.discovered_package_dir
 
     dist = Distribution(dist_kwargs)
     dist.has_ext_modules = lambda: True

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -126,11 +126,14 @@ class PyProject:
         """Get package directory mapping from setuptools config."""
         return self.setuptools_config.get("package-dir", {})
 
+    @property
+    def discovered_package_dir(self) -> dict:
+        return {pkg: self.get_package_path(pkg) for pkg in self.packages}
+
     @cached_property
     def packages(self) -> list[str]:
         """Get list of packages to include."""
         packages = self._discover_packages()
-        logger.debug("Package list: %s", packages)
         return packages
 
     def _discover_packages(self) -> list[str]:

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -2,7 +2,7 @@ import dataclasses
 import tomllib
 from collections import defaultdict
 from collections.abc import Mapping
-from functools import cached_property, partial
+from functools import cached_property
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, Optional, TypeAlias
@@ -148,12 +148,17 @@ class PyProject:
             case PackageList(packages=pkgs): return pkgs
             case AutoDiscover(): return rooted_find_packages()
             case FindConfig(cfg=cfg):
-                if not isinstance(cfg.get("where"), list):
+                try:
+                    where_cfg = cfg.pop("where")
+                except KeyError:
                     return rooted_find_packages(**cfg)
+
+                if isinstance(where_cfg, str):
+                    where_cfg = [where_cfg]
 
                 self._package_where = {
                     package: where
-                    for where in cfg.pop("where")
+                    for where in where_cfg
                     for package in rooted_find_packages(where=where, **cfg)
                 }
                 return list(self._package_where)

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -3,7 +3,6 @@ import tomllib
 from collections import defaultdict
 from collections.abc import Mapping
 from functools import cached_property
-from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, Optional, TypeAlias
 
@@ -13,8 +12,6 @@ from pyproject_metadata import StandardMetadata
 from setuptools import find_packages
 
 from .hwh_config import HwhConfig
-
-logger = getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -97,8 +97,7 @@ class PyProject:
     @property
     def setuptools_config(self) -> dict:
         """Get setuptools configuration from pyproject.toml."""
-        result = self.toml.get("tool", {}).get("setuptools", {})
-        return result
+        return self.toml.get("tool", {}).get("setuptools", {})
 
     @cached_property
     def setuptools_package_config(self) -> SetuptoolsPackageConfig:
@@ -133,8 +132,7 @@ class PyProject:
     @cached_property
     def packages(self) -> list[str]:
         """Get list of packages to include."""
-        packages = self._discover_packages()
-        return packages
+        return self._discover_packages()
 
     def _discover_packages(self) -> list[str]:
         """Discover packages using setuptools.packages.find configuration."""

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -40,7 +40,7 @@ class PyProject:
             )
         self._data: Optional[Dict[str, Any]] = None
         # This is set in _discover_packages, called by the packages property
-        self._package_directories: Optional[Mapping[str, str]] = None
+        self._package_where: Optional[Mapping[str, str]] = None
 
     @property
     def toml(self):

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -152,8 +152,8 @@ class PyProject:
 
                 self._package_where = {
                     package: where
-                    for package in rooted_find_packages(where=where)
-                    for where in cfg["where"]
+                    for where in cfg.pop("where")
+                    for package in rooted_find_packages(where=where, **cfg)
                 }
                 return list(self._package_where)
 

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -1,6 +1,11 @@
+import dataclasses
 import tomllib
+from collections import defaultdict
+from collections.abc import Mapping
+from functools import cached_property, partial
+from logging import getLogger
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, TypeAlias
 
 from packaging.requirements import Requirement
 from packaging.version import Version
@@ -8,6 +13,24 @@ from pyproject_metadata import StandardMetadata
 from setuptools import find_packages
 
 from .hwh_config import HwhConfig
+
+logger = getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class PackageList:
+    packages: list[str]
+
+
+@dataclasses.dataclass(frozen=True)
+class FindConfig:
+    cfg: dict
+
+
+class AutoDiscover:
+    pass
+
+SetuptoolsPackageConfig: TypeAlias = FindConfig | PackageList | AutoDiscover
 
 
 class PyProject:
@@ -19,6 +42,8 @@ class PyProject:
                 f"Couldn't locate pyproject.toml from {str(self.project_dir)}"
             )
         self._data: Optional[Dict[str, Any]] = None
+        # This is set in _discover_packages, called by the packages property
+        self._package_directories: Optional[Mapping[str, str]] = None
 
     @property
     def toml(self):
@@ -72,75 +97,80 @@ class PyProject:
     @property
     def setuptools_config(self) -> dict:
         """Get setuptools configuration from pyproject.toml."""
-        return self.toml.get("tool", {}).get("setuptools", {})
+        result = self.toml.get("tool", {}).get("setuptools", {})
+        return result
+
+    @cached_property
+    def setuptools_package_config(self) -> SetuptoolsPackageConfig:
+        cfg = self.setuptools_config
+        try:
+            packages = cfg.pop("packages")
+        except KeyError:
+            return AutoDiscover()
+
+        if isinstance(packages, list):
+            return PackageList(packages)
+
+        try:
+            find_cfg = packages["find"]
+        except KeyError:
+            raise TypeError("setuptools.packages must be list or find configuration. "
+                            "See https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration")
+
+        if not isinstance(find_cfg, dict):
+            raise TypeError("setuptools.packages.find must be table.")
+        return FindConfig(find_cfg)
 
     @property
     def package_dir(self) -> dict:
         """Get package directory mapping from setuptools config."""
         return self.setuptools_config.get("package-dir", {})
 
-    @property
+    @cached_property
     def packages(self) -> list[str]:
         """Get list of packages to include."""
-        return self._discover_packages()
+        packages = self._discover_packages()
+        logger.debug("Package list: %s", packages)
+        return packages
 
     def _discover_packages(self) -> list[str]:
         """Discover packages using setuptools.packages.find configuration."""
         setuptools_config = self.setuptools_config
 
-        # Check for packages.find
-        packages_find = setuptools_config.get("packages", {}).get("find", {})
-        if packages_find:
-            # Get base directory for package search
-            where = packages_find.get("where", ["."])
-            if isinstance(where, str):
-                where = [where]
+        def rooted_find_packages(where='.', **kargs):
+            return find_packages(**kargs, where=self.project_dir/where)
 
-            # Get include/exclude patterns. Default to include all.
-            include = packages_find.get("include", ["*"])
-            exclude = packages_find.get("exclude", [])
+        # May overwrite this later
+        self._package_where = defaultdict(lambda: '.')
 
-            # Convert paths relative to project root
-            search_dirs = [self.project_dir / w for w in where]
+        match self.setuptools_package_config:
+            case PackageList(packages=pkgs): return pkgs
+            case AutoDiscover(): return rooted_find_packages()
+            case FindConfig(cfg=cfg):
+                if not isinstance(cfg.get("where"), list):
+                    return rooted_find_packages(**cfg)
 
-            found_packages = []
-            for search_dir in search_dirs:
-                found = find_packages(
-                    where=str(search_dir), include=include, exclude=exclude
-                )
-                found_packages.extend(found)
+                self._package_where = {
+                    package: where
+                    for package in rooted_find_packages(where=where)
+                    for where in cfg["where"]
+                }
+                return list(self._package_where)
 
-            if found_packages:
-                return found_packages
-
-        # Fallback to direct package list if specified
-        packages = setuptools_config.get("packages", None)
-        if isinstance(packages, list):
-            return packages
-
-        # Default to package name as last resort
-        return [self.package_name]
+            case _: raise TypeError("Bug in setuptools_package_config")
 
     def get_package_path(self, package: str) -> Path:
         """Convert a package name to its directory path."""
-        base = self.project_dir
-
-        # Check for config, where setuptools.packages.find section defines "where"
-        packages_find = self.setuptools_config.get("packages", {}).get("find", {})
-        if where_paths := packages_find.get("where", []):
-            if isinstance(where_paths, str):
-                where_paths = [where_paths]
-            # Use the first where path for now
-            # TODO: figure out the cases where there are multiple "where"s.
-            # havent' seen one yet?
-            base = base / where_paths[0]
-
-        return base / package.replace(".", "/")
+        # HACK: Make sure we compute the list of packages if needed
+        self.packages
+        return self.project_dir / self._package_where[package] / package.replace(".", "/")
 
     def get_all_package_paths(self) -> list[Path]:
         """Get paths for all configured packages."""
         # For src layout, we only want the root package path
         # added to stop duplicates
+        # FIXME(jbayn): Is above comment because we crawl the package for every
+        #               subpackage cython file? We should not do that.
         if len(self.packages) > 0:
             root_pkg = self.packages[0].split(".")[0]
             return [self.get_package_path(root_pkg)]

--- a/tests/integration/test_package_layouts.py
+++ b/tests/integration/test_package_layouts.py
@@ -21,24 +21,22 @@ def test_src_layout_installation(tmp_path, pip_arguments):
 
     # Create directory structure
     package_tree = {
-        "src": {
-            "mypackage": {
-                "core": {
-                    "base.pyx": """
+        "mypackage": {
+            "core": {
+                "base.pyx": """
 def get_value():
     return 42
 """,
-                },
-                "utils": {
-                    "helpers.py": """
+            },
+            "utils": {
+                "helpers.py": """
 def helper_func():
     return "helper"
 """,
-                },
             }
         }
     }
-    create_package_structure(package_dir, package_tree)
+    create_package_structure(package_dir / "src", package_tree)
 
     # Create pyproject.toml with only modern configuration
     with open(package_dir / "pyproject.toml", "w") as f:

--- a/tests/unit/test_package_discovery.py
+++ b/tests/unit/test_package_discovery.py
@@ -122,7 +122,7 @@ version = "0.1.0"
 
 [tool.setuptools.packages.find]
 where = ["src"]
-exclude = ["mypackage*tests", "mypackage*experimental"] 
+exclude = ["mypackage*tests", "mypackage*experimental"]
 """)
 
     project = PyProject(project_dir)


### PR DESCRIPTION
The current package discovery configuration is a bit broken.

1. There are numerous places that it assumes that `tool.setuptools.packages` is a table/dict, when it can often be a list.
2. We're parsing the `tool.setuptools.packages.find` dict in multiple places and some of that parsing has bugs in it.
3. We  reimplement some setuptools logic needlessly
4. We diverge from the default setuptools behaviour for the default configuration (flat layouts should work, source layouts need configuration).
5. The package_dir structure isn't being filled in correctly (I'm not sure what would be correct in this case)

This MR addresses all these things:

1. and 2. are solved by implementing one place where we parse the `tool.setuptools.packages` object. 3. and 4. are solved by delegating to `find_packages` as quickly as possible for every given configuration. 5. is solved by, when building the package list, if we have been given a `where` clause, exhaustively mapping every package to its path, available from the new `PyProject.discovered_package_dir` property.

I also made `PyProject.packages` a `cached_property` so we don't have to be shy about using it multiple times.