### PR TITLE
Set Distribution.install_requires for build_wheel

### DIFF
--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -392,7 +392,7 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     # Build extensions first, this now handles all the Distribution setup
     dist_kwargs = _build_extension(
         _is_editable_install(), config_settings=config_settings
-    )
+    ) | {"install_requires": [d.name for d in project.runtime_dependencies]}
 
     from wheel.bdist_wheel import bdist_wheel as wheel_command
 

--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -392,7 +392,8 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     # Build extensions first, this now handles all the Distribution setup
     dist_kwargs = _build_extension(
         _is_editable_install(), config_settings=config_settings
-    ) | {"install_requires": [d.name for d in project.runtime_dependencies]}
+    ) | {"install_requires": [str(d) for d in project.runtime_dependencies],
+         "extras_require": project.toml.get("project", {}).get("optional-dependencies", None)}
 
     from wheel.bdist_wheel import bdist_wheel as wheel_command
 

--- a/tests/integration/test_installation.py
+++ b/tests/integration/test_installation.py
@@ -1,3 +1,4 @@
+from ..utils.package_utils import create_test_package
 from ..utils.venv_utils import run_in_venv
 from ..utils.verification_utils import verify_editable_install, verify_installation
 
@@ -64,3 +65,34 @@ print("Wheel installation successful!")
     script_path = simple_cython_package / "scripts/verify_wheel.py"
     script_path.write_text(verify_script)
     verify_installation(test_env, script_path, "Wheel installation successful!")
+
+
+def test_dependency_installation(test_env, tmp_path, backend_dir):
+    # Create a simple package with dependencies
+    cython_files = {
+        "simple.pyx": """
+def dependencies_available():
+    import numpy as np
+    import pandas as pd
+    return "Dependencies OK"
+"""
+    }
+
+    # Create test package with specific dependencies
+    package_dir = create_test_package(
+        tmp_path,
+        "dependency-test",
+        cython_files,
+        backend_dir,
+        dependencies=["numpy>=1.20.0", "pandas>=1.3.0"],
+    )
+
+    run_in_venv(
+        test_env,
+        ["pip", "install", str(package_dir), "--no-build-isolation"],
+        show_output=True,
+    )
+
+    pip_freeze = run_in_venv(test_env, ["pip", "freeze"])
+    assert "numpy==" in pip_freeze.stdout
+    assert "pandas==" in pip_freeze.stdout


### PR DESCRIPTION
Fixes #21 

There's a broken test here: `test_multiple_versions`. I spent about 10m looking at it and I can't work out what that test is doing or which part of it has broken. Maybe you could give me a hand?

I've changed the dependencies to return `Sequence` instead of `set`. This is because there are some (extremely niche) cases where the dependency installation order is important and yet pip doesn't resolve it properly. It doesn't *matter* if these are sequences or sets, and we might make some niche issues impossible to work around by throwing away dependency ordering.  (It also doesn't matter a-priori if a dependency appears twice).