### PR TITLE
Import setuptools before Cython to fix build failures

### DIFF
--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -1,3 +1,4 @@
+import setuptools  # This must come before importing Cython!
 import json
 import shutil
 import site


### PR DESCRIPTION
Currently, `python -m build` fails without the `--no-isolation` flag, because we allow `Cython` to be imported before `setuptools`.

This means that the old `distutils.command.build_ext` is used as a base rather than `setuptools.command.build_ext`. This then results in the following crash:

```
Traceback (most recent call last):
  File "/home/jamie/Work/prod/.venv/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
    main()
  File "/home/jamie/Work/prod/.venv/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 373, in main
    json_out["return_val"] = hook(**hook_input["kwargs"])
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jamie/Work/prod/.venv/lib/python3.11/site-packages/pyproject_hooks/_in_process/_in_process.py", line 280, in build_wheel
    return _build_backend().build_wheel(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-gw_n8e2s/lib/python3.11/site-packages/hwh_backend/build.py", line 389, in build_wheel
    dist_kwargs = _build_extension(
                  ^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-gw_n8e2s/lib/python3.11/site-packages/hwh_backend/build.py", line 359, in _build_extension
    "ext_modules": _get_ext_modules(project, config_settings=config_settings),
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-gw_n8e2s/lib/python3.11/site-packages/hwh_backend/build.py", line 240, in _get_ext_modules
    logger.debug("Final extensions: %s", {len(x) for x in cythonized})
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/build-env-gw_n8e2s/lib/python3.11/site-packages/hwh_backend/build.py", line 240, in <setcomp>
    logger.debug("Final extensions: %s", {len(x) for x in cythonized})
                                          ^^^^^^
TypeError: object of type 'Extension' has no len()
```

We also get the following warning at the top of the output which helpfully explains how to solve the problem:

```
/nix/store/nfh9h3fn73vz4zfmq0vxsyx6f4pcwabv-python3.11-setuptools-72.1.0/lib/python3.11/site-packages/_distutils_hack/__init__.py:17: UserWarning: Distutils was imported before Setuptools, but importing Setuptools also replaces the `distutils` module in `sys.modules`. This may lead to undesirable behaviors or errors. To avoid these issues, avoid using distutils directly, ensure that setuptools is installed in the traditional way (e.g. not an editable install), and/or make sure that setuptools is always imported before distutils.
  warnings.warn(
/nix/store/nfh9h3fn73vz4zfmq0vxsyx6f4pcwabv-python3.11-setuptools-72.1.0/lib/python3.11/site-packages/_distutils_hack/__init__.py:32: UserWarning: Setuptools is replacing distutils. Support for replacing an already imported distutils is deprecated. In the future, this condition will fail. Register concerns at https://github.com/pypa/setuptools/issues/new?template=distutils-deprecation.yml
```

By putting `import setuptools` at the top of `build.py`, `setuptools` has always replaced `distutils` by the time `Cython` is imported. Hence, `python -m build` now succeeds.