### PR TITLE
Make `PyProject.package_version` return `None` if version not specified

### DIFF
--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -354,7 +354,7 @@ def _build_extension(
 
     dist_kwargs = {
         "name": name,
-        "version": str(project.package_version),
+        "version": project.package_version,
         "ext_modules": _get_ext_modules(project, config_settings=config_settings),
         "packages": project.packages,
         "package_data": {pkg: ["*.pxd", "*.so"] for pkg in project.packages},

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -85,7 +85,9 @@ class PyProject:
     @property
     def package_version(self) -> Optional[Version]:
         """Get the package version from pyproject.toml"""
-        return self.metadata.version
+        # NOTE: Do not use StandardMetadata as it parses a missing version
+        #       as "0.0.0" (???)
+        return self.toml["project"].get("version")
 
     def get_hwh_config(self) -> HwhConfig:
         # TODO: switch to property


### PR DESCRIPTION
If not provided, `version` is being set to `"0.0.0"`, rather than `None`. This defeats tools like `setuptools-scm` which guard their behaviour on `dist.metadata.version == None`