### PR TITLE
Fix broken pypi workflows

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -28,6 +28,9 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+          fetch-depth: 0
+          fetch-tags: true
     
     - name: Set up Python 3.11
       uses: actions/setup-python@v4

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -25,7 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-        pip install -e .
 
     - name: Build package
       run: |

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -18,8 +18,7 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
-
-    
+        
     - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
@@ -29,6 +28,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build twine
+        pip install -e .[test]
+
+    - name: Run tests
+      run: |
+        python -m pytest
 
     - name: Build package
       run: |

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -25,12 +25,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-        pip install -e .[test]
-    
-    - name: Run tests
-      run: |
-        python -m pytest
-    
+        pip install -e .
+
     - name: Build package
       run: |
         python -m build

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -15,6 +15,10 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
     
     - name: Set up Python 3.11
       uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.11"
-license = { text = "MIT" }
+license = "MIT"
 keywords = ["cython", "build", "backend", "pep517"]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ keywords = ["cython", "build", "backend", "pep517"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Cython",


### PR DESCRIPTION
testpypi-publish failed due to tags not being fetched. 
pyproject.toml's license identified switched to SPDX format