### PR TITLE
Add Cython 3 support

### DIFF
--- a/.github/workflows/pr-gatekeeper.yml
+++ b/.github/workflows/pr-gatekeeper.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pr-gatekeeper.yml
+++ b/.github/workflows/pr-gatekeeper.yml
@@ -12,27 +12,26 @@ on:
     branches: [ master ]
 
 jobs:
-  validate:
+  test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.11"
-    
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[test]
-    
+      run: uv sync --extra test
+
     - name: Run tests
-      run: |
-        python -m pytest
-        
+      run: uv run pytest
+
     - name: Verify build
-      run: |
-        pip install build
-        python -m build
+      run: uv run python -m build

--- a/.github/workflows/pr-gatekeeper.yml
+++ b/.github/workflows/pr-gatekeeper.yml
@@ -10,6 +10,17 @@ on:
       - '.gitignore'
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - 'LICENSE'
+      - '.gitignore'
+
+concurrency:
+  # https://docs.github.com/en/actions/how-tos/write-workflows/choose-when-workflows-run/control-workflow-concurrency
+  # cancel running joobs if something is pushed to the same PR
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/pr-gatekeeper.yml
+++ b/.github/workflows/pr-gatekeeper.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,4 +1,4 @@
-name: Publish to PyPi
+name: Publish to PyPI
 
 on:
   workflow_dispatch:
@@ -10,54 +10,55 @@ on:
         type: string
 
 jobs:
-  verify-release:
-    runs-on: ubuntu-latest
+  test:
     if: github.event.inputs.confirm_release == 'yes'
-    
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.12", "3.13"]
+
     steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
     - name: Check for release tag
       run: |
         if [[ -z "${{ github.ref_name }}" || ! "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
           echo "Error: This workflow must be run on a release tag (e.g., v1.0.0)"
           exit 1
         fi
-  
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: uv sync --extra test
+
+    - name: Run tests
+      run: uv run pytest
+
   publish:
-    needs: verify-release
+    needs: test
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
-          fetch-depth: 0
-          fetch-tags: true
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11"
-    
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-        pip install -e .[test]
-    
-    - name: Run tests
-      run: |
-        python -m pytest
-    
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
+
     - name: Build package
-      run: |
-        python -m build
-    
-    - name: Check distribution
-      run: |
-        twine check dist/*
-    
+      run: uv build
+
     - name: Publish to PyPI
+      run: uv publish
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
-      run: |
-        twine upload dist/*
+        UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13", "3.14"]
+        python-version: ["3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -1,7 +1,7 @@
 name: Run Tests
 
 on:
-  workflow_dispatch:  # Manual trigger
+  workflow_dispatch:
     inputs:
       pytest_args:
         description: 'Additional pytest arguments'
@@ -12,20 +12,21 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.11"
-    
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -e .[test]
-    
+      run: uv sync --extra test
+
     - name: Run tests
-      run: |
-        python -m pytest ${{ inputs.pytest_args }}
+      run: uv run pytest ${{ inputs.pytest_args }}

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up uv
       uses: astral-sh/setup-uv@v5

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -1,4 +1,5 @@
-name: Test PyPI
+name: Publish to TestPyPI
+
 on:
   workflow_dispatch:
     inputs:
@@ -9,42 +10,48 @@ on:
         type: string
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  test:
     if: github.event.inputs.confirm_publish == 'yes'
-    
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.12", "3.13"]
+
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         fetch-tags: true
-        
-    - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.11"
-    
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-        pip install -e .[test]
+      run: uv sync --extra test
 
     - name: Run tests
-      run: |
-        python -m pytest
+      run: uv run pytest
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Set up uv
+      uses: astral-sh/setup-uv@v5
 
     - name: Build package
-      run: |
-        python -m build
-    
-    - name: Check distribution
-      run: |
-        twine check dist/*
-    
+      run: uv build
+
     - name: Publish to TestPyPI
+      run: uv publish --publish-url https://test.pypi.org/legacy/
       env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
-      run: |
-        twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+        UV_PUBLISH_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/.github/workflows/testpypi-publish.yml
+++ b/.github/workflows/testpypi-publish.yml
@@ -19,7 +19,7 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
         fetch-tags: true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Tests Passing](https://github.com/mkgessen/hwh-backend/actions/workflows/test-only.yml/badge.svg)](https://github.com/mkgessen/hwh-backend/actions/workflows/test-only.yml)
 
 Provides [PEP-517](https://peps.python.org/pep-0517/) build hooks for building
-Cython extensions with setuptools. Supports Cython 3.1+ and NumPy 2+.
+Cython extensions with setuptools. Supports Cython 0.29 and 3.1+.
 
 Ideally similar functionality would be provided an actual setuptools backend.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Ideally similar functionality would be provided an actual setuptools backend.
 
 - Python 3.11+
 - Cython 0.29 or 3.1+
-- NumPy <2 with Cython 0.29 and 2.0+ for Cython 3(optional, for numpy integration)
+- NumPy <2 with Cython 0.29 and 2.0+ for Cython 3 (optional, for numpy integration)
 - Linux
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -82,12 +82,13 @@ Extension module configuration:
 - `extra_link_args`: Additional linker arguments
 - `runtime_library_dirs`: Runtime library search paths
 
-Site-packages configuration via `site_packages`:
+### `[tool.hwh.cython]` — site-packages
 
-- `"purelib"`: Use sysconfig.get_path("purelib")
-- `"user"`: Use site.getusersitepackages()
-- `"site"`: Use site.getsitepackages()
-- `"none"`: No automatic site-packages paths
+- `site_packages`: Controls which site-packages paths are added to include/library dirs:
+  - `"purelib"`: Use sysconfig.get_path("purelib") (default)
+  - `"user"`: Use site.getusersitepackages()
+  - `"site"`: Use site.getsitepackages()
+  - `"none"`: No automatic site-packages paths
 
 ### `[tool.hwh.cython.compiler_directives]`
 
@@ -174,6 +175,7 @@ force = false
 use_numpy_include = true
 numpy_api_version = "NPY_1_7_API_VERSION"
 legacy_implicit_noexcept = false
+site_packages = "purelib"
 
 [tool.hwh.cython.modules]
 sources = ["src/mylib/*.pyx"]
@@ -183,7 +185,6 @@ library_dirs = ["/usr/local/lib"]
 libraries = ["mylib"]
 extra_compile_args = ["-O3"]
 runtime_library_dirs = ["/usr/local/lib"]
-site_packages = "purelib"
 
 [tool.hwh.cython.compiler_directives]
 boundscheck = false

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Cython extensions with setuptools. Supports Cython 0.29 and 3.1+.
 the Python version you're running:
 
 - Cython>=3.1 is supported for Python 3.12/3.13
-- Cython>=0.29 is supported for Python 3.11 (see branch [cython-0.29](https://github.com/mkgessen/hwh-backend/tree/cython-0.29))
+- Cython==0.29 is supported for Python 3.11 (see branch [cython-0.29](https://github.com/mkgessen/hwh-backend/tree/cython-0.29))
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ Cython compiler directives configuration:
 
 ```toml
 [tool.hwh.cython.compiler_directives]
-language_level = "3str"    # Python language level ("2", "3", "3str" for Cython 3+)
 binding = false            # Generate Python wrapper functions
 boundscheck = false        # Array bounds checking
 wraparound = false        # Negative indexing

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ Core Cython build configuration:
 - `force`: Force rebuild of extensions (default: false)
 - `use_numpy_include`: Include numpy headers in compilation (default: false)
 - `numpy_api_version`: Define NPY_NO_DEPRECATED_API macro to suppress NumPy deprecation warnings (default: none). Set to "NPY_1_7_API_VERSION" to eliminate warnings
-- `legacy_implicit_noexcept`: Noexcept flag to stop Cython 3 spamming in case of explicit noexcept statements (default: true) and I will change the name :)
+- `legacy_implicit_noexcept`: Controls exception handling for `cdef` functions without an explicit exception spec (default: false)
+  - `false`: Cython 3 default — functions check for exceptions after every call
+  - `true`: Cython 0.29 behavior — functions are implicitly `noexcept`, no exception checking.
 
 ### `[tool.hwh.cython.modules]`
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@
 [![Tests Passing](https://github.com/mkgessen/hwh-backend/actions/workflows/test-only.yml/badge.svg)](https://github.com/mkgessen/hwh-backend/actions/workflows/test-only.yml)
 
 Provides [PEP-517](https://peps.python.org/pep-0517/) build hooks for building
-Cython extensions with setuptools. Currently supports Cython 0.29.
+Cython extensions with setuptools. Supports Cython 3.1+ and NumPy 2+.
 
 Ideally similar functionality would be provided an actual setuptools backend.
 
 ## Requirements
 
-- Python 3.11
-- Cython 0.29.xx
+- Python 3.11+
+- Cython 0.29 or 3.1+
+- NumPy <2 with Cython 0.29 and 2.0+ for Cython 3(optional, for numpy integration)
 - Linux
 
 ## Features
@@ -60,6 +61,8 @@ Core Cython build configuration:
 - `nthreads`: Number of parallel compilation threads (default: CPU count)
 - `force`: Force rebuild of extensions (default: false)
 - `use_numpy_include`: Include numpy headers in compilation (default: false)
+- `numpy_api_version`: Define NPY_NO_DEPRECATED_API macro to suppress NumPy deprecation warnings (default: none). Set to "NPY_1_7_API_VERSION" to eliminate warnings
+- `legacy_implicit_noexcept`: Noexcept flag to stop Cython 3 spamming in case of explicit noexcept statements (default: true) and I will change the name :)
 
 ### `[tool.hwh.cython.modules]`
 
@@ -87,6 +90,7 @@ Cython compiler directives configuration:
 
 ```toml
 [tool.hwh.cython.compiler_directives]
+language_level = "3str"    # Python language level ("2", "3", "3str" for Cython 3+)
 binding = false            # Generate Python wrapper functions
 boundscheck = false        # Array bounds checking
 wraparound = false        # Negative indexing
@@ -103,7 +107,7 @@ type_version_tag = true  # Enable CPython's type attribute cache
 ```
 
 For more information, see
-[Cython docs](https://cython.readthedocs.io/en/0.29.x/src/userguide/source_files_and_compilation.html)
+[Cython docs](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html)
 and
 [Setup tools extension docs](https://setuptools.pypa.io/en/latest/userguide/ext_modules.html)
 
@@ -123,14 +127,16 @@ python -m build --wheel --no-isolation \
     --config-settings annotate=true \
     --config-settings nthreads=4 \
     --config-settings force=true \
-    --config-settings linetrace=true
+    --config-settings linetrace=true \
+    --config-settings legacy_implicit_noexcept=true
 
 # Using pip
 pip install -e . \
     --config-setting annotate=true \
     --config-setting nthreads=4 \
     --config-setting force=true \
-    --config-setting linetrace=true
+    --config-setting linetrace=true \
+    --config-setting legacy_implicit_noexcept=true
 ```
 
 ## Logging
@@ -142,13 +148,13 @@ pip install --config-setting verbose=debug  # Options: debub, info, warning
 ### `[tool.hwh.cython.compiler_directives]`
 
 HWH exposes the most of Cython's compiler directives. See
-[compiler directives](https://cython.readthedocs.io/en/0.29.x/src/userguide/source_files_and_compilation.html#compiler-directives)
+[compiler directives](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives)
 
 ### Example `pyproject.toml`
 
 ```toml pyproject.toml
 [build-system]
-requires = ["hwh-backend", "Cython<3.0.0"]
+requires = ["hwh-backend", "Cython>=3.1.0"]
 build-backend = "hwh_backend.build"
 
 [project]
@@ -161,6 +167,8 @@ annotate = true
 nthreads = 4
 force = false
 use_numpy_include = true
+numpy_api_version = "NPY_1_7_API_VERSION"
+legacy_implicit_noexcept = false
 
 [tool.hwh.cython.modules]
 sources = ["src/mylib/*.pyx"]

--- a/README.md
+++ b/README.md
@@ -5,11 +5,16 @@
 Provides [PEP-517](https://peps.python.org/pep-0517/) build hooks for building
 Cython extensions with setuptools. Supports Cython 0.29 and 3.1+.
 
-Ideally similar functionality would be provided an actual setuptools backend.
+:warning: `pip intall hwh-backend` will support different Cython versions depending on 
+the Python version you're running:
+
+- Cython>=3.1 is supported for Python 3.12/3.13
+- Cython>=0.29 is supported for Python 3.11 (see branch [cython-0.29](https://github.com/mkgessen/hwh-backend/tree/cython-0.29))
+
 
 ## Requirements
 
-- Python 3.11+
+- Python 3.11 - 3.13
 - Cython 0.29 or 3.1+
 - NumPy <2 with Cython 0.29 and 2.0+ for Cython 3 (optional, for numpy integration)
 - Linux

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,98 @@
+# Python 3.12/3.13 Compatibility TODO
+
+## Issues Identified
+
+### 1. `wheel` Internal API Misuse (High — `build.py:370-392`)
+
+Two problems in `BdistWheelCommand`:
+
+- **`self.user_options = config_settings` (line 376)**: `user_options` in distutils commands
+  is a class-level list of `(long, short, desc)` tuples used for CLI option parsing. Assigning
+  a settings dict here is incorrect and could break with newer wheel versions.
+- **`cmd.distribution.script_name = "fubar"` (line 389)**: A distutils internal hack to
+  silence an error. The value "fubar" is meaningless but the assignment is necessary —
+  `Distribution()` leaves `script_name=None` when constructed programmatically, and
+  distutils `build_py` calls `os.path.abspath(script_name)` which fails on None.
+  Fixed by using the conventional `"setup.py"` string instead.
+
+### 2. `pyproject_metadata` API Drift (High — `parser.py:62`)
+
+`StandardMetadata.from_pyproject(self.toml)` — in `pyproject-metadata>=0.8.0` the signature
+changed. Unrecognised keys in `pyproject.toml` now raise by default unless
+`allow_extra_keys=True` is passed. The minimum pinned version is `>=0.7.0`, so this can break
+silently on dependency update.
+
+### 3. `setuptools` Version Floor for Python 3.12 (Medium — `pyproject.toml:2,27`)
+
+`distutils` was removed from the Python 3.12 stdlib. setuptools bundles its own distutils
+shim, but `setuptools>=68.0` is the bare minimum. `setuptools>=69.0` is recommended for
+reliable 3.12 support.
+
+### 4. `packaging` Undeclared Dependency (Low — `parser.py:10-11`)
+
+`from packaging.requirements import Requirement` and `from packaging.version import Version`
+are used but `packaging` is not listed in `pyproject.toml` dependencies. Currently available
+transitively via setuptools/pip but should be declared explicitly.
+
+### 5. `numpy` Hard Dependency (Low — `pyproject.toml:30`)
+
+`numpy>=2.0.0` is a required runtime dependency, but numpy is only needed when
+`use_numpy_include = true`. Forces numpy on every consumer of hwh-backend unnecessarily.
+Should be an optional dependency.
+
+### 6. Tooling Targets Hardcoded to 3.11 (Low — `pyproject.toml:62,72,89`)
+
+`target-version = "py311"` in `[tool.black]` and `[tool.ruff]`, and `python_version = "3.11"`
+in `[tool.mypy]`. Needs updating when 3.12+ support lands.
+
+---
+
+## Solutions
+
+### Fix 1: `wheel` Internal API — Replace `BdistWheelCommand` subclass
+
+The `BdistWheelCommand` subclass overrides `finalize_options` and `run` but abuses internal
+attributes. The goal is: force `root_is_pure = False` so the wheel is tagged as non-pure.
+
+**Plan:**
+- Remove the override of `self.user_options` entirely — it serves no purpose here.
+  `config_settings` are already parsed upstream by `_parse_build_settings`.
+- Replace `cmd.distribution.script_name = "fubar"` with the correct setuptools approach:
+  set `Distribution.metadata.name` directly, or use `dist.script_name` only if required by
+  the installed version of setuptools (check via `hasattr`).
+- Alternatively, avoid subclassing `bdist_wheel` entirely and configure the command via
+  `dist.command_options` dict, which is the stable public API.
+
+**Minimal safe fix:**
+```python
+class BdistWheelCommand(wheel_command):
+    def finalize_options(self):
+        super().finalize_options()
+        self.root_is_pure = False
+    # Remove run() override — it only calls super().run()
+```
+And replace `cmd.distribution.script_name = "fubar"` with the distribution being constructed
+with a proper `name` already set (which it is via `dist_kwargs["name"]`). The `script_name`
+hack may only be needed for older setuptools; test whether it can simply be removed.
+
+### Fix 2: `pyproject_metadata` API — Pin version and pass `allow_extra_keys`
+
+**Plan:**
+- Bump minimum version pin to `pyproject-metadata>=0.8.0` in `pyproject.toml`.
+- Update the call in `parser.py:62`:
+  ```python
+  StandardMetadata.from_pyproject(self.toml, allow_extra_keys=True)
+  ```
+  `allow_extra_keys=True` is needed because `pyproject.toml` will contain `[tool.hwh]`
+  and other non-standard sections that `pyproject-metadata` doesn't know about.
+- Verify behaviour with a test that includes `[tool.hwh]` keys in a fixture pyproject.toml.
+
+### Fix 3: `setuptools` Version Floor
+
+**Plan:**
+- Bump both occurrences in `pyproject.toml` from `>=68.0` to `>=69.0`:
+  - `build-system.requires` (line 2)
+  - `project.dependencies` (line 27)
+- `setuptools>=69.0` ensures the bundled distutils shim fully covers the removed stdlib
+  `distutils` in Python 3.12.
+- Also add `"Programming Language :: Python :: 3.12"` to classifiers once validated.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [
     { name = "Mathias von Essen", email = "3090690+mkgessen@users.noreply.github.com" },
 ]
 readme = "README.md"
+# WARNING: Doesn't run on 3.14
 requires-python = ">=3.12"
 license = "MIT"
 keywords = ["cython", "build", "backend", "pep517"]
@@ -19,7 +20,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
     "Programming Language :: Cython",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel>=0.40.0", "setuptools-scm>=8.0.0"]
+requires = ["setuptools>=69.0", "wheel>=0.40.0", "setuptools-scm>=8.0.0"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -24,11 +24,11 @@ classifiers = [
     "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-    "setuptools>=68.0",
+    "setuptools>=69.0",
     "wheel>=0.40.0",
     "Cython>=3.1.0",
     "numpy>=2.0.0",
-    "pyproject-metadata>=0.7.0",
+    "pyproject-metadata>=0.8.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "hwh-backend"
 dynamic = ["version"]
-description = "Setuptools based backend supporting Cython extensions"
+description = "Setuptools based backend supporting Cython 3+ extensions"
 authors = [
     { name = "Mathias von Essen", email = "3090690+mkgessen@users.noreply.github.com" },
 ]
@@ -26,7 +26,8 @@ classifiers = [
 dependencies = [
     "setuptools>=68.0",
     "wheel>=0.40.0",
-    "Cython<3.0.0",
+    "Cython>=3.1.0",
+    "numpy>=2.0.0",
     "pyproject-metadata>=0.7.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,16 @@ authors = [
     { name = "Mathias von Essen", email = "3090690+mkgessen@users.noreply.github.com" },
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 license = "MIT"
 keywords = ["cython", "build", "backend", "pep517"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Cython",
     "Topic :: Software Development :: Build Tools",
     "Topic :: Software Development :: Libraries :: Python Modules",
@@ -59,7 +61,7 @@ addopts = "-v --cov=hwh_backend --cov-report=term-missing"
 
 [tool.black]
 line-length = 88
-target-version = ["py311"]
+target-version = ["py312"]
 include = '\.pyi?$'
 
 [tool.isort]
@@ -69,7 +71,7 @@ multi_line_output = 3
 include_trailing_comma = true
 
 [tool.mypy]
-python_version = "3.11"
+python_version = "3.12"
 warn_return_any = true
 warn_unused_configs = true
 disallow_untyped_defs = true
@@ -86,4 +88,4 @@ select = [
 ]
 ignore = []
 line-length = 88
-target-version = "py311"
+target-version = "py312"

--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -344,6 +344,18 @@ def _build_extension(inplace: bool = False, config_settings={}) -> dict[str, Any
     return dist_kwargs
 
 
+try:
+    from setuptools.command.bdist_wheel import bdist_wheel as _bdist_wheel
+except ImportError:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+
+class BdistWheelCommand(_bdist_wheel):
+    def finalize_options(self):
+        super().finalize_options()
+        self.root_is_pure = False
+
+
 def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     """Build wheel with explicit editable install handling."""
 
@@ -367,18 +379,6 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     else:
         logger.debug("Extensions already built, skipping")
 
-    from wheel.bdist_wheel import bdist_wheel as wheel_command
-
-    class BdistWheelCommand(wheel_command):
-        def finalize_options(self):
-            super().finalize_options()
-            self.root_is_pure = False
-            self.user_options = config_settings
-
-        def run(self):
-            logger.debug("Running custom bdist_wheel command")
-            super().run()
-
     # Create distribution using same config from _build_extension
     dist = Distribution(dist_kwargs)
     dist.cmdclass = {"build_ext": EditableBuildExt}
@@ -386,7 +386,10 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
 
     cmd = BdistWheelCommand(dist)
     cmd.dist_dir = wheel_directory
-    cmd.distribution.script_name = "fubar"
+    # script_name must be a valid path string; Distribution() leaves it None
+    # when constructed programmatically, causing os.path.abspath() to fail
+    # inside distutils build_py.
+    cmd.distribution.script_name = "setup.py"
     cmd.ensure_finalized()
     logger.debug("Starting wheel build")
     cmd.run()

--- a/src/hwh_backend/build.py
+++ b/src/hwh_backend/build.py
@@ -1,19 +1,17 @@
-import setuptools  # This must come before importing Cython!
 import json
 import shutil
 import site
 import sysconfig
 import warnings
 from collections.abc import Sequence
-from itertools import chain
 from importlib.metadata import distributions
+from itertools import chain
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+import setuptools  # This must come before importing Cython!
 from Cython.Build import cythonize
-from setuptools.build_meta import (
-    build_editable as _build_editable,
-)
+from setuptools.build_meta import build_editable as _build_editable
 from setuptools.command.build_ext import build_ext
 from setuptools.dist import Distribution
 from setuptools.extension import Extension
@@ -66,8 +64,6 @@ def get_sitepackages(option: SitePackages):
             return site.getsitepackages()
         case SitePackages.NONE:
             return []
-
-
 
 
 def resolve_package_path(
@@ -126,16 +122,19 @@ def _get_ext_modules(project: PyProject, config_settings: Optional[dict] = None)
     package_paths = project.get_all_package_paths()
     logger.debug(f"Package paths: {package_paths}")
 
-    pyx_paths = _collect_pyx_paths(
-        package_paths,
-        config.sources,
-        config.exclude_dirs
-    )
+    pyx_paths = _collect_pyx_paths(package_paths, config.sources, config.exclude_dirs)
 
-    linetrace =  _CONFIG_OPTIONS.get("linetrace", False)
+    linetrace = _CONFIG_OPTIONS.get("linetrace", False)
+    legacy_implicit_noexcept = _CONFIG_OPTIONS.get(
+        "legacy_implicit_noexcept", config.legacy_implicit_noexcept
+    )
     extra_compile_args = config.extra_compile_args
     if linetrace:
         extra_compile_args += ["-DCYTHON_TRACE_NOGIL=1"]
+
+    # NumPy API version macro. To stop those annoying warnings
+    if config.numpy_api_version:
+        extra_compile_args += [f"-DNPY_NO_DEPRECATED_API={config.numpy_api_version}"]
 
     # Create Extensions
     ext_modules = []
@@ -188,11 +187,15 @@ def _get_ext_modules(project: PyProject, config_settings: Optional[dict] = None)
     compiler_directives = config.compiler_directives.as_dict()
     if linetrace:
         compiler_directives["linetrace"] = True
+    if legacy_implicit_noexcept:
+        compiler_directives["legacy_implicit_noexcept"] = True
 
     logger.debug(f"\n=== FORCE = {force} ")
     logger.debug(f"\n=== ANNOTATE = {annotate} ")
     logger.debug(f"\n=== NTHREADS = {nthreads} ")
     logger.debug(f"\n=== LINETRACE = {linetrace} ")
+    logger.debug(f"\n=== LEGACY_IMPLICIT_NOEXCEPT = {legacy_implicit_noexcept} ")
+    logger.debug(f"\n=== COMPILER_DIRECTIVES = {compiler_directives} ")
 
     cythonized = cythonize(
         ext_modules,
@@ -295,6 +298,9 @@ def _parse_build_settings(config_settings: dict | None = None) -> dict[str, bool
         if config_settings.get("linetrace"):
             result["linetrace"] = True
 
+        if config_settings.get("legacy_implicit_noexcept"):
+            result["legacy_implicit_noexcept"] = True
+
     except Exception:
         logger.exception("Error parsing config settings")
         return {}
@@ -302,9 +308,7 @@ def _parse_build_settings(config_settings: dict | None = None) -> dict[str, bool
     return result
 
 
-def _build_extension(
-    inplace: bool = False, config_settings={}
-) -> dict[str, Any]:
+def _build_extension(inplace: bool = False, config_settings={}) -> dict[str, Any]:
     """Build the extension modules with better editable install handling.
 
     returns: dict of kwargs for Distribution object
@@ -352,7 +356,9 @@ def build_wheel(wheel_directory, config_settings=None, metadata_directory=None):
     dist_kwargs = {
         "entry_points": project.entrypoints,
         "install_requires": [str(d) for d in project.runtime_dependencies],
-        "extras_require": project.toml.get("project", {}).get("optional-dependencies", None)
+        "extras_require": project.toml.get("project", {}).get(
+            "optional-dependencies", None
+        ),
     }
     if not _EXTENSIONS_BUILT:
         dist_kwargs |= _build_extension(
@@ -423,7 +429,9 @@ def build_sdist(sdist_directory, config_settings=None):
     return _build_sdist(sdist_directory, config_settings)
 
 
-def _pyx_paths_from_sources(sources: Sequence[str], package_paths: Sequence[Path]) -> List[Path]:
+def _pyx_paths_from_sources(
+    sources: Sequence[str], package_paths: Sequence[Path]
+) -> List[Path]:
     logger.debug("Using explicit sources: %s", sources)
     package_paths = set(package_paths)
     pyx_paths = []
@@ -438,11 +446,15 @@ def _pyx_paths_from_sources(sources: Sequence[str], package_paths: Sequence[Path
             pyx_paths.append(pyx_path)
 
     if discarded_orphans:
-        warnings.warn("The following sources were orphaned from packages and have been ignored: "
-                        f"{discarded_orphans}")
+        warnings.warn(
+            "The following sources were orphaned from packages and have been ignored: "
+            f"{discarded_orphans}"
+        )
     if discarded_non_pyx:
-        warnings.warn("The following sources will not be cythonised as they are not .pyx files: "
-                      f"{discarded_non_pyx}")
+        warnings.warn(
+            "The following sources will not be cythonised as they are not .pyx files: "
+            f"{discarded_non_pyx}"
+        )
     return pyx_paths
 
 
@@ -459,10 +471,10 @@ def _find_cython_files(package_paths: Sequence[Path]) -> List[Path]:
         return found_pyx
 
     logger.debug("=== finding cython files ===")
-    pyx_files = list(chain.from_iterable(
-        find(pkg_path) for pkg_path in package_paths))
+    pyx_files = list(chain.from_iterable(find(pkg_path) for pkg_path in package_paths))
     logger.debug(f"Found .pyx files: {pyx_files}")
     return pyx_files
+
 
 def _exclude_extensions(pyx_paths: Sequence[Path], exclude_dirs: Sequence[str]):
     logger.debug("Using exclude dirs: %s", exclude_dirs)
@@ -481,14 +493,15 @@ def _exclude_extensions(pyx_paths: Sequence[Path], exclude_dirs: Sequence[str]):
         logger.debug("Nothing excluded")
     return included
 
+
 def _collect_pyx_paths(
-        package_paths: Sequence[Path],
-        sources: Sequence[str],
-        exclude_dirs: Sequence[str]
+    package_paths: Sequence[Path], sources: Sequence[str], exclude_dirs: Sequence[str]
 ):
-    pyx_paths = (_pyx_paths_from_sources(sources, package_paths)
-                 if sources else
-                 _find_cython_files(package_paths))
+    pyx_paths = (
+        _pyx_paths_from_sources(sources, package_paths)
+        if sources
+        else _find_cython_files(package_paths)
+    )
 
     if exclude_dirs:
         return _exclude_extensions(pyx_paths, exclude_dirs)

--- a/src/hwh_backend/hwh_config.py
+++ b/src/hwh_backend/hwh_config.py
@@ -31,9 +31,6 @@ class CythonCompilerWarningDirectives:
 @dataclass
 class CythonCompilerDirectives:
     # see https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives
-    # Use 3str for Cython 3+, still defaults to 3.
-    # TODO: Change default in future versions
-    language_level: str = "3str"
     binding: bool = True  # Changed from False (new default in Cython 3+)
     boundscheck: bool = True
     wraparound: bool = True
@@ -59,11 +56,13 @@ class CythonCompilerDirectives:
 
     def as_dict(self) -> dict[str, str | bool]:
         """Convert directives to dictionary for cythonize()."""
-        return {
+        directives = {
             key: value
             for key, value in self.__dict__.items()
             if not key.startswith("_") and value is not None
         }
+        directives["language_level"] = "3str"
+        return directives
 
     def __post_init__(self):
         """Validate types and values after initialization."""

--- a/src/hwh_backend/hwh_config.py
+++ b/src/hwh_backend/hwh_config.py
@@ -120,7 +120,7 @@ class CythonConfig:
     # Set to True to restore Cython 0.29 exception handling (default: true)
     # TODO: Set default to true in future versions
     # TODO: check that this doesn't upset when building with 0.29
-    legacy_implicit_noexcept: bool = True
+    legacy_implicit_noexcept: bool = False
 
     def __post_init__(self):
         if isinstance(self.compiler_directives, dict):

--- a/src/hwh_backend/hwh_config.py
+++ b/src/hwh_backend/hwh_config.py
@@ -30,17 +30,11 @@ class CythonCompilerWarningDirectives:
 
 @dataclass
 class CythonCompilerDirectives:
-    # only language level "3" is supported, so hardcoding it
-    _language_level: str = field(init=False, default="3", repr=False)
-
-    @property
-    def language_level(self) -> str:
-        """Language level is fixed at '3' for Python 3 compatibility."""
-        return self._language_level
-
-    # see https://cython.readthedocs.io/en/0.29.x/src/userguide/source_files_and_compilation.html#compiler-directives
-    # Defaults are documentation's defauls
-    binding: bool = False
+    # see https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives
+    # Use 3str for Cython 3+, still defaults to 3.
+    # TODO: Change default in future versions
+    language_level: str = "3str"
+    binding: bool = True  # Changed from False (new default in Cython 3+)
     boundscheck: bool = True
     wraparound: bool = True
     initializedcheck: bool = False
@@ -66,20 +60,14 @@ class CythonCompilerDirectives:
     def as_dict(self) -> dict[str, str | bool]:
         """Convert directives to dictionary for cythonize()."""
         return {
-            "language_level": self.language_level,  # Always include this
-            **{
-                key: value
-                for key, value in self.__dict__.items()
-                if not key.startswith("_") and value is not None
-            },
+            key: value
+            for key, value in self.__dict__.items()
+            if not key.startswith("_") and value is not None
         }
 
     def __post_init__(self):
         """Validate types and values after initialization."""
         for field_name, field_value in self.__dict__.items():
-            if field_name == "_language_level":
-                continue  # ignore language_level, since it should be always 3
-
             field_type = self.__annotations__[field_name]
 
             # Type validation
@@ -121,6 +109,18 @@ class CythonConfig:
 
     # include_dirs += numpy.get_include()
     use_numpy_include: bool = False
+
+    # Allow passing NPY_NO_DEPRECATED_API to avoid NumPy deprecation warnings
+    # Set to None (default) to still see warnings, or specify API version like "NPY_1_7_API_VERSION" to supress.
+    # TODO: Rename and make something more elegant
+    numpy_api_version: str | None = None
+
+    # Enable legacy exception handling behavior for Cython 3+
+    # This is to stop spamming with noexcept warnings
+    # Set to True to restore Cython 0.29 exception handling (default: true)
+    # TODO: Set default to true in future versions
+    # TODO: check that this doesn't upset when building with 0.29
+    legacy_implicit_noexcept: bool = True
 
     def __post_init__(self):
         if isinstance(self.compiler_directives, dict):
@@ -166,6 +166,10 @@ class CythonConfig:
             runtime_library_dirs=runtime_library_dirs,
             site_packages=cython_config.get("site_packages") or SitePackages.PURELIB,
             use_numpy_include=cython_config.get("use_numpy_include", False),
+            numpy_api_version=cython_config.get("numpy_api_version"),
+            legacy_implicit_noexcept=cython_config.get(
+                "legacy_implicit_noexcept", False
+            ),
         )
 
 

--- a/src/hwh_backend/hwh_config.py
+++ b/src/hwh_backend/hwh_config.py
@@ -10,7 +10,7 @@ class Language(StrEnum):
 
 
 class SitePackages(StrEnum):
-    PURELIB = "pure"  # use sysconfig.get_path('purelib')
+    PURELIB = "purelib"  # use sysconfig.get_path('purelib')
     USER = "user"  # use site.getusersitepackages()
     SITE = "site"  # use site.getsitepackages()
     NONE = "none"  # don't add sitepackages at all

--- a/src/hwh_backend/parser.py
+++ b/src/hwh_backend/parser.py
@@ -59,7 +59,7 @@ class PyProject:
 
     @property
     def metadata(self) -> StandardMetadata:
-        return StandardMetadata.from_pyproject(self.toml)
+        return StandardMetadata.from_pyproject(self.toml, allow_extra_keys=True)
 
     @property
     def runtime_dependencies(self) -> Sequence[Requirement]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,7 @@ def sample_pyproject():
 [build-system]
 requires = [
     "hwh-backend",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 

--- a/tests/integration/test_package_layouts.py
+++ b/tests/integration/test_package_layouts.py
@@ -44,7 +44,7 @@ def helper_func():
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 
@@ -142,7 +142,7 @@ def slow_util_func():
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 

--- a/tests/unit/test_build.py
+++ b/tests/unit/test_build.py
@@ -1,7 +1,9 @@
 import pytest
 from pathlib import Path
+from unittest.mock import patch
 
 from hwh_backend.build import (
+    BdistWheelCommand,
     _parse_build_settings,
     _collect_pyx_paths,
 )
@@ -79,3 +81,23 @@ def test_parse_invalid_build_settings():
 
 def test_parse_empty_build_settings():
     assert _parse_build_settings(None) == {}
+
+
+def test_bdist_wheel_command_should_not_define_run():
+    # run() only called super() — no reason to override it
+    assert "run" not in BdistWheelCommand.__dict__
+
+
+def test_bdist_wheel_command_finalize_options_should_preserve_user_options():
+    # Arrange — user_options is a class-level list of option tuples defined by wheel
+    from setuptools.dist import Distribution
+    dist = Distribution({"name": "test-pkg", "version": "0.1.0"})
+    cmd = BdistWheelCommand(dist)
+    expected_user_options = BdistWheelCommand.user_options
+
+    # Act — mock super() so we only execute our finalize_options body
+    with patch.object(BdistWheelCommand.__bases__[0], "finalize_options"):
+        cmd.finalize_options()
+
+    # Assert — user_options must not be overwritten with config_settings
+    assert cmd.user_options is expected_user_options

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -24,6 +24,36 @@ def test_site_packages_config():
     assert config.site_packages == SitePackages.PURELIB
 
 
+def test_site_packages_purelib_string_value():
+    """SitePackages.PURELIB should have string value 'purelib' to match docs and sysconfig key."""
+    assert SitePackages.PURELIB == "purelib"
+
+
+def test_site_packages_from_pyproject_modules_section(tmp_path):
+    """site_packages should be read from [tool.hwh.cython.modules], not [tool.hwh.cython]."""
+    import tomli_w
+    from hwh_backend.parser import PyProject
+
+    test_config = {
+        "project": {"name": "test-project", "version": "0.1.0"},
+        "tool": {
+            "hwh": {
+                "cython": {
+                    "site_packages": "site",
+                }
+            }
+        },
+    }
+
+    pyproject_path = tmp_path / "pyproject.toml"
+    with open(pyproject_path, "wb") as f:
+        tomli_w.dump(test_config, f)
+
+    project = PyProject(tmp_path)
+    config = project.get_hwh_config().cython
+    assert config.site_packages == SitePackages.SITE
+
+
 def test_invalid_language():
     with pytest.raises(ValueError):
         CythonConfig(language="invalid")

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -39,28 +39,17 @@ def test_compiler_directives_types():
         CythonCompilerDirectives(binding="not_a_bool")
 
 
-def test_cython_compiler_directives_constant_language_level():
-    # TODO: delete - no point of testing language level, since we only accept 3
+def test_cython_compiler_directives_default_language_level():
+    # Arrange
     directives = CythonCompilerDirectives()
 
-    # Test that language_level is constant
-    assert directives.language_level == "3"
-    with pytest.raises(AttributeError):
-        directives.language_level = "2"
+    # Assert default is Cython 3 language level
+    assert directives.language_level == "3str"
 
-    # Test that as_dict() includes language_level
+    # Assert as_dict() includes language_level
     result = directives.as_dict()
     assert "language_level" in result
-    assert result["language_level"] == "3"
-
-    # Test that private fields are not included
-    assert "_language_level" not in result
-
-    # Test that all other fields work normally
-    directives.binding = True
-    result = directives.as_dict()
-    assert result["binding"] is True
-    assert result["language_level"] == "3"  # Still present and unchanged
+    assert result["language_level"] == "3str"
 
 
 def test_library_config():

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -69,16 +69,15 @@ def test_compiler_directives_types():
         CythonCompilerDirectives(binding="not_a_bool")
 
 
-def test_cython_compiler_directives_default_language_level():
-    # Arrange
-    directives = CythonCompilerDirectives()
+def test_language_level_not_user_configurable():
+    """language_level is hardcoded to 3str and should not be settable by the user."""
+    with pytest.raises(TypeError):
+        CythonCompilerDirectives(language_level="2")
 
-    # Assert default is Cython 3 language level
-    assert directives.language_level == "3str"
 
-    # Assert as_dict() includes language_level
-    result = directives.as_dict()
-    assert "language_level" in result
+def test_language_level_always_3str_in_dict():
+    """as_dict() must always include language_level=3str regardless of other directives."""
+    result = CythonCompilerDirectives().as_dict()
     assert result["language_level"] == "3str"
 
 

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -8,6 +9,27 @@ from hwh_backend.parser import PyProject
 from ..utils.package_utils import create_package_structure, create_test_package
 from ..utils.venv_utils import create_virtual_env, run_in_venv, setup_test_env
 from ..utils.verification_utils import verify_editable_install, verify_installation
+
+
+def test_metadata_should_pass_allow_extra_keys_to_standard_metadata(tmp_path):
+    """StandardMetadata.from_pyproject must be called with allow_extra_keys=True
+    so that pyproject-metadata>=0.8.0 does not raise on unknown [project] keys."""
+    # Arrange
+    (tmp_path / "pyproject.toml").write_text("""
+[project]
+name = "test-pkg"
+version = "0.1.0"
+""")
+    project = PyProject(tmp_path)
+    mock_metadata = MagicMock()
+
+    # Act
+    with patch("hwh_backend.parser.StandardMetadata") as mock_cls:
+        mock_cls.from_pyproject.return_value = mock_metadata
+        _ = project.metadata
+
+    # Assert
+    mock_cls.from_pyproject.assert_called_once_with(project.toml, allow_extra_keys=True)
 
 
 @pytest.fixture

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -84,7 +84,7 @@ def test_package_discovery_explicit(package_test_dir, tmp_path):
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 
@@ -113,7 +113,7 @@ def test_package_discovery_find(package_test_dir, tmp_path):
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 
@@ -145,7 +145,7 @@ def test_package_discovery_default_src_layout(package_test_dir, tmp_path):
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 
@@ -179,7 +179,7 @@ def test_package_discovery_default_flat_layout(tmp_path):
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 
@@ -211,7 +211,7 @@ def test_package_discovery_different_names(package_test_dir):
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 

--- a/tests/utils/package_utils.py
+++ b/tests/utils/package_utils.py
@@ -16,7 +16,7 @@ def create_pyproject_toml(
 [build-system]
 requires = [
     "hwh-backend @ file://{backend_dir}",
-    "Cython<3.0.0"
+    "Cython>=3.1.0"
 ]
 build-backend = "hwh_backend.build"
 

--- a/tests/utils/venv_utils.py
+++ b/tests/utils/venv_utils.py
@@ -69,7 +69,7 @@ def setup_test_env(venv_dir: Path, backend_dir: Optional[Path] = None) -> None:
             "install",
             "setuptools",
             "wheel",
-            "Cython<3.0.0",
+            "Cython>=3.1.0",
             "pyproject-metadata",
             "build",
         ],


### PR DESCRIPTION
## Breaking changes

- Removes support for Python 3.11 and Cython 0.29. Cython 0.29 / Python 3.11 development will be in it's own branch (https://github.com/mkgessen/hwh-backend/tree/cython-0.29) 
- Adds support for Cython 3.1 onwards with Python 3.12 and 3.13 (both are tested by CI)
- Adds `legacy_implicit_noexcept` to stop Cython 3 from spamming in case of explicit noexcept statements